### PR TITLE
Add wrapping to picture name

### DIFF
--- a/src/Components/FileList/FileElement/FileElement.css
+++ b/src/Components/FileList/FileElement/FileElement.css
@@ -3,13 +3,12 @@
   border: 2px solid #999;
   border-radius: 5px;
   background-color: #ccc;
-  display: grid;
-  grid-template-areas: "pic title";
-  grid-template-columns: 36% 62%;
+  display: flex;
+  flex-direction: row;
   gap: 2%;
   align-items: center;
   width: 95%;
-  margin: 5px 2%;
+  margin:10px 2%;
   transition: box-shadow 0.3s ease;
   transition: border-color 0.3s ease;
 }
@@ -24,6 +23,7 @@
 }
 
 .file-element img {
+  flex:1;
   max-width: 100px;
   margin: 5px;
   height: auto;
@@ -31,8 +31,11 @@
 }
 
 .file-element p {
+  flex: 1;
   grid-area: title;
   overflow: hidden;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 .file-element:hover .cross {
   opacity: 1;

--- a/src/Components/FileList/FileElement/FileElement.tsx
+++ b/src/Components/FileList/FileElement/FileElement.tsx
@@ -16,9 +16,34 @@ const FileElement: React.FC<FileElementProps> = ({
 }) => {
   const [fileUrl, setFileUrl] = useState("");
   const fileCard = useRef<null | HTMLDivElement>(null);
+  const titleRef = useRef<null | HTMLParagraphElement>(null);
+
   useEffect(() => {
     setFileUrl(blob.blob);
   }, [blob]);
+
+  // This useEffect will adjust the font size of the title to fit the container
+  useEffect(() => {
+    const adjustFontSize = () => {
+      if (titleRef.current) {
+        const maxWidth = fileCard.current ? fileCard.current.offsetWidth : 0;
+        let fontSize = parseInt(
+          window.getComputedStyle(titleRef.current).fontSize,
+          10,
+        );
+
+        // Reduce font size till text fits the container or the font size reaches minimum threshold
+        while (titleRef.current.scrollWidth > maxWidth && fontSize > 10) {
+          fontSize--;
+          titleRef.current.style.fontSize = `${fontSize}px`;
+        }
+      }
+    };
+
+    adjustFontSize();
+    window.addEventListener("resize", adjustFontSize);
+    return () => window.removeEventListener("resize", adjustFontSize);
+  }, []);
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault(); // Prevent default navigation
@@ -53,7 +78,13 @@ const FileElement: React.FC<FileElementProps> = ({
       onClick={handleClick}
     >
       <img src={fileUrl} alt={blob.name} />
-      <p className="file-title black bold unselectable">{blob.name}</p>
+      <p
+        ref={titleRef}
+        className="file-title black bold unselectable"
+        style={{ fontSize: "inherit" }}
+      >
+        {blob.name}
+      </p>
       <div className="cross" onClick={deleteImage}></div>
     </div>
   );

--- a/src/Components/FileList/FileList.css
+++ b/src/Components/FileList/FileList.css
@@ -4,6 +4,8 @@
   grid-area: b;
   padding: 5px;
   width: 100%;
+  margin-top:4em;
+  overflow-x: hidden;
 }
 
 @media only screen and (min-width: 850px) {


### PR DESCRIPTION
Add top margin to fit the drag and drop component.
Add word-wrapping property to fix overflow of file name.