### PR TITLE
Update CSS for ProgressBar and Modal components.

### DIFF
--- a/src/Components/FileList/FileList.css
+++ b/src/Components/FileList/FileList.css
@@ -4,17 +4,27 @@
   grid-area: b;
   padding: 5px;
   width: 100%;
+  margin-top: 67px; /* Adjust margin to be at the same height of the draganddroptComponent */
+  overflow-x: hidden;
 }
 
 @media only screen and (min-width: 850px) {
   .file-list.empty {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
 }
 
 @media only screen and (max-width: 850px) {
   .file-list.empty {
     width: 96%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
   .file-list {
     display: flex;
@@ -30,7 +40,6 @@
 
 .no-element {
   display: none;
-  margin-top: 50%;
 }
 
 .no-element.active {

--- a/src/Components/FileList/FileList.tsx
+++ b/src/Components/FileList/FileList.tsx
@@ -71,7 +71,7 @@ const FileList: React.FC<FileListProps> = ({
       onContextMenu={(e) => e.preventDefault()}
     >
       <div
-        className={`file-list ${blobs.length === 0 ? "empty" : ""}` }
+        className={`file-list ${blobs.length === 0 ? "empty" : ""}`}
         style={{
           position: "relative",
           height: "500px",

--- a/src/Components/FileList/FileList.tsx
+++ b/src/Components/FileList/FileList.tsx
@@ -71,7 +71,7 @@ const FileList: React.FC<FileListProps> = ({
       onContextMenu={(e) => e.preventDefault()}
     >
       <div
-        className="file-list"
+        className={`file-list ${blobs.length === 0 ? "empty" : ""}` }
         style={{
           position: "relative",
           height: "500px",

--- a/src/Components/Input/Input.css
+++ b/src/Components/Input/Input.css
@@ -96,7 +96,8 @@ textarea:disabled {
   display: grid;
   grid-template-rows: auto 1fr auto;
   grid-template-columns: 2fr auto;
-  column-gap: 30px;                           
+  column-gap: 30px;             
+}              
 
 .input-label {
   margin-top: 10px;

--- a/src/Components/Input/Input.css
+++ b/src/Components/Input/Input.css
@@ -1,20 +1,134 @@
+/* Text box styles */
 textarea {
   transition: box-shadow 0.5s ease-in-out;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  box-sizing: border-box;
+  width: 100%; /* Sets textarea width to be 100% of its parent container. */
+  height: auto;
+  min-height: 40px;
+  max-height: 97px;
+  resize: none;
+  background-color: rgb(220, 219, 219);
+  overflow-y: hidden;
+  padding: 5px;
+  font-family: Arial, sans-serif;
+  font-size: 20px;
+  font-weight: 400; /* Normal weight */
+  color: #000000; /* Dark gray */
+  text-decoration: none;
 }
+
 textarea:disabled {
   background-color: #4e4e4e7a;
   border: solid 2px black;
 }
+
 .rejected {
   border: solid 2px red;
 }
-@media (prefers-color-schem: light) {
+
+/* Light mode box shadow */
+@media (prefers-color-scheme: light) {
   textarea {
     box-shadow: 0 0 0 0 black;
   }
 }
-@media (prefers-color-schem: dark) {
+
+/* Dark mode box shadow */
+@media (prefers-color-scheme: dark) {
   textarea {
     box-shadow: 0 0 0 0 white;
   }
+  .open-icon {
+    color: white;
+  }
+}
+
+/* Show more button container */
+.show-more-container {
+  align-self: end;
+  justify-self: end;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.show-more-container label {
+  width: fit-content;
+}
+
+.underlined {
+  text-decoration: underline;
+}
+
+.data-container h1 {
+  grid-column: 1;
+  grid-row: 1 / span 2; /* Le textarea s'étend sur les deux lignes */
+  text-align: left;
+  margin-left: 10px;
+  font-size: 35px;
+  width: 100%;
+}
+
+.open-icon {
+  cursor: pointer;
+  font-size: 15px;
+  text-decoration: underline;
+  color: darkgrey;
+}
+
+.button {
+  background-color: #dcdcdc;
+}
+
+.input-error {
+  border: 2px solid red; /* Outline element with a red border */
+}
+
+/* Grid container for the input elements */
+.input-grid-container {
+  display: grid;
+  grid-template-columns: auto 1fr; /* Two columns layout */
+  grid-template-rows: auto 1fr auto; /* Three rows layout */
+  gap: 11px;
+}
+
+.input-grid-container {
+  display: grid;
+  grid-template-rows: auto 1fr auto; /* 1ère colonne pour le label, 2ème pour le textarea et 3ème pour le bouton "show more" */
+  grid-template-columns: auto auto;       /* 2 lignes */
+  gap: 8px;                           /* Espace entre les colonnes et les lignes */
+}
+
+.input-label {
+  margin-top: 10px;
+  grid-column: 1;
+  grid-row: 1;
+  text-align: left;
+  margin-left: 10px;
+  font-weight: bold;
+}
+
+.textarea-container {
+  grid-column: 1;
+  grid-row: 2 / span 2; /* Le textarea s'étend sur les deux lignes */
+  justify-content: left; /* Center horizontally within the container */
+  align-items: center; /* Center vertically within the container */
+  width: 40vw; /* Make the container take up the full width */
+  margin-left: 10px;
+}
+
+.button-container {
+  margin-top: -5px;
+  align-items: center;
+  align-self: center;
+  grid-column: 2;
+  grid-row: 2;
+  justify-self: start; /* Aligner le button-container au début de la colonne */
+}
+
+.show-more-container {
+  margin-bottom: -15px;
+  grid-column: 1;
+  grid-row: 3;
 }

--- a/src/Components/Input/Input.css
+++ b/src/Components/Input/Input.css
@@ -1,4 +1,3 @@
-/* Text box styles */
 textarea {
   transition: box-shadow 0.5s ease-in-out;
   border: 1px solid #ccc;
@@ -63,7 +62,7 @@ textarea:disabled {
 
 .data-container h1 {
   grid-column: 1;
-  grid-row: 1 / span 2; /* Le textarea s'étend sur les deux lignes */
+  grid-row: 1 / span 2;
   text-align: left;
   margin-left: 10px;
   font-size: 35px;
@@ -95,10 +94,9 @@ textarea:disabled {
 
 .input-grid-container {
   display: grid;
-  grid-template-rows: auto 1fr auto; /* 1ère colonne pour le label, 2ème pour le textarea et 3ème pour le bouton "show more" */
-  grid-template-columns: auto auto;       /* 2 lignes */
-  gap: 8px;                           /* Espace entre les colonnes et les lignes */
-}
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 2fr auto;
+  column-gap: 30px;                           
 
 .input-label {
   margin-top: 10px;
@@ -111,10 +109,10 @@ textarea:disabled {
 
 .textarea-container {
   grid-column: 1;
-  grid-row: 2 / span 2; /* Le textarea s'étend sur les deux lignes */
-  justify-content: left; /* Center horizontally within the container */
-  align-items: center; /* Center vertically within the container */
-  width: 40vw; /* Make the container take up the full width */
+  grid-row: 2 / span 2; 
+  justify-content: left;
+  align-items: center; 
+  width: 100%; 
   margin-left: 10px;
 }
 

--- a/src/Components/Input/Input.tsx
+++ b/src/Components/Input/Input.tsx
@@ -2,12 +2,9 @@ import "./Input.css";
 import React, { useState } from "react";
 import Input from "../../Model/Input-Model";
 import Section from "../../Model/Section-Model";
-
 import Modal from "../Modal/Modal";
-
 import editIcon from "../../assets/edit1.svg";
 import acceptIcon from "../../assets/acceptIcon.svg";
-
 import { FormClickActions } from "../../Utils/EventChannels";
 import { useTranslation } from "react-i18next";
 
@@ -18,6 +15,7 @@ interface InputProps {
   modal: React.MutableRefObject<HTMLDivElement | null>;
   imgs: { title: string; url: string }[];
   propagateChange: (inputInfo: Input) => void;
+  onModalStateChange: (isOpen: boolean) => void;
 }
 
 const MAX_CHAR_IN_ROW = 37;
@@ -36,6 +34,7 @@ const InputComponent: React.FC<InputProps> = ({
   modal,
   imgs,
   propagateChange,
+  onModalStateChange,
 }) => {
   const { t } = useTranslation();
   const [isActive, setIsActive] = useState(false);
@@ -109,66 +108,28 @@ const InputComponent: React.FC<InputProps> = ({
   };
 
   return (
-    <div className="input-container">
-      <label htmlFor={inputInfo.id}>
+    <div className="input-grid-container">
+      <label htmlFor={inputInfo.id} className="input-label">
         {parent.label.charAt(0).toUpperCase() + parent.label.slice(1)}{" "}
         {inputInfo.label.replace(/_/gi, " ")} :
       </label>
-      <div className="textbox-container">
+      <div className="textarea-container">
         <textarea
           id={inputInfo.id}
           ref={textarea}
           value={inputInfo.value}
           disabled={inputInfo.disabled}
-          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-            const current = event.target as HTMLTextAreaElement;
-            resizeTextarea(current);
+          onChange={(event) => {
             inputInfo.value = event.target.value;
             propagateChange(inputInfo);
+            resizeTextarea(textarea.current);
           }}
-          onInput={(event: React.FormEvent<HTMLTextAreaElement>) => {
-            const current = event.target as HTMLTextAreaElement;
-            resizeTextarea(current); // Added here
+          onInput={() => {
+            resizeTextarea(textarea.current);
           }}
           className="text-box"
           rows={1}
         />
-        <div className="button-container">
-          <button
-            className={`button ${isActive ? "active" : ""}`}
-            onClick={() => handleStateChange(inputInfo)}
-          >
-            {property === "default" ? (
-              <img
-                src={acceptIcon}
-                alt={t("approveButton")}
-                width="20"
-                height="20"
-              />
-            ) : property === "approved" ? (
-              <img
-                src={editIcon}
-                alt={t("approveButton")}
-                width="20"
-                height="20"
-              />
-            ) : property === "modified" ? (
-              <img
-                src={acceptIcon}
-                alt={t("modifyButton")}
-                width="20"
-                height="20"
-              />
-            ) : (
-              <img
-                src={acceptIcon}
-                alt={t("approveButton")}
-                width="20"
-                height="20"
-              />
-            )}
-          </button>
-        </div>
       </div>
       {/* Show more functionality moved here for better separation */}
       {inputInfo.value.split("\n").length +
@@ -182,6 +143,7 @@ const InputComponent: React.FC<InputProps> = ({
             className="open-icon"
             onClick={() => {
               modal.current?.classList.add("active");
+              onModalStateChange(true);
             }}
           >
             {t("showMoreButton")}
@@ -198,10 +160,47 @@ const InputComponent: React.FC<InputProps> = ({
             imgs={imgs}
             close={() => {
               modal.current?.classList.remove("active");
+              onModalStateChange(false);
             }}
           />
         </div>
       )}
+      <div className="button-container">
+        <button
+          className={`button ${isActive ? "active" : ""}`}
+          onClick={() => handleStateChange(inputInfo)}
+        >
+          {property === "default" ? (
+            <img
+              src={acceptIcon}
+              alt={t("approveButton")}
+              width="20"
+              height="20"
+            />
+          ) : property === "approved" ? (
+            <img
+              src={editIcon}
+              alt={t("approveButton")}
+              width="20"
+              height="20"
+            />
+          ) : property === "modified" ? (
+            <img
+              src={acceptIcon}
+              alt={t("modifyButton")}
+              width="20"
+              height="20"
+            />
+          ) : (
+            <img
+              src={acceptIcon}
+              alt={t("approveButton")}
+              width="20"
+              height="20"
+            />
+          )}
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/Components/Modal/Modal.css
+++ b/src/Components/Modal/Modal.css
@@ -65,6 +65,11 @@
   font-weight: 400; /* Normal weight */
   color: #000000; /* Dark gray */
   text-decoration: none;
+  word-wrap: break-word;
+}
+
+.no-scrollBar {
+  overflow: hidden;
 }
 
 /* Styles du textarea de la carte */
@@ -80,6 +85,7 @@
   color: #000000; /* Dark gray */
   text-decoration: none;
   overflow-y: visible;
+  word-wrap: break-word;
 }
 
 /* Styles du pied de page de la carte */

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./Modal.css";
 import closeIcon from "../../assets/close_icon.png";
 import Carousel from "../Carousel/Carousel";
 import { useTranslation } from "react-i18next";
+
 interface ModalProps {
   text: string;
   imgs: Image[]; // Array of Image objects
@@ -14,8 +15,8 @@ interface ModalProps {
 }
 
 interface Image {
-  url: string; // Image URL
-  title: string; // Image title (optional)
+  url: string;
+  title: string;
 }
 
 const Modal: React.FC<ModalProps> = ({
@@ -26,8 +27,7 @@ const Modal: React.FC<ModalProps> = ({
   imgs,
 }) => {
   const { t } = useTranslation();
-  const [isEditing, setIsEditing] = useState(false); // Added state for edit mode
-
+  const [isEditing, setIsEditing] = useState(false);
   const handleOverlayTextChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>,
   ) => {
@@ -49,6 +49,18 @@ const Modal: React.FC<ModalProps> = ({
     setIsEditing(!isEditing); // Toggle edit mode
   };
 
+  useEffect(() => {
+    const divElements = document.querySelectorAll(".card-content");
+
+    divElements.forEach((div) => {
+      if (isEditing) {
+        div.classList.add("no-scrollBar");
+      } else {
+        div.classList.remove("no-scrollBar");
+      }
+    });
+  }, [isEditing]);
+
   return (
     <div className="overlay" onClick={handleOverlayClick} ref={toRef}>
       <div className="pic-container">
@@ -65,7 +77,7 @@ const Modal: React.FC<ModalProps> = ({
           {isEditing ? (
             <textarea
               value={text} // Use the current text state value
-              onChange={handleOverlayTextChange} // Update text state here
+              onChange={handleOverlayTextChange}
               style={{ width: "100%", height: "300px" }}
             />
           ) : (

--- a/src/Components/ProgressBar/ProgressBar.css
+++ b/src/Components/ProgressBar/ProgressBar.css
@@ -10,8 +10,8 @@
 
 .progress-wrapper {
   position: fixed;
-  right: 60px;
-  top: 40px;
+  right: 20px;
+  top: 60px;
 }
 
 .section {

--- a/src/Components/Section/Section.tsx
+++ b/src/Components/Section/Section.tsx
@@ -15,6 +15,7 @@ interface sectionPorps {
   }[];
   imgs: { title: string; url: string }[];
   propagateChange: (section: Section) => void;
+  onModalStateChange: (isOpen: boolean) => void;
 }
 
 const SectionComponent: React.FC<sectionPorps> = ({
@@ -23,12 +24,17 @@ const SectionComponent: React.FC<sectionPorps> = ({
   modals,
   imgs,
   propagateChange,
+  onModalStateChange,
 }) => {
   const handleInputChange = (newInfo: Input) => {
     sectionInfo.inputs.find((cur) => cur.label == newInfo.label)!.value =
       newInfo.value;
     propagateChange(sectionInfo);
   };
+  const handleModalStateChange = (isOpen: boolean) => {
+    onModalStateChange(isOpen);
+  };
+
   return (
     <div className={sectionInfo.label + "-container data-section"}>
       <h1 className="title underlined">{sectionInfo.title}</h1>
@@ -48,6 +54,7 @@ const SectionComponent: React.FC<sectionPorps> = ({
             modal={modal}
             imgs={imgs}
             propagateChange={handleInputChange}
+            onModalStateChange={handleModalStateChange}
           />
         );
       })}

--- a/src/Pages/CapturPage/CapturPage.tsx
+++ b/src/Pages/CapturPage/CapturPage.tsx
@@ -151,9 +151,14 @@ function CapturPage() {
             file={toShow}
             calculateCaptureCounter={calculateCaptureCounter}
           />
-            <button className="submit-btn" type="button" onClick={Submit} disabled={state.data.pics.length === 0}>
-              {t("submitButton")}
-            </button>
+          <button
+            className="submit-btn"
+            type="button"
+            onClick={Submit}
+            disabled={state.data.pics.length === 0}
+          >
+            {t("submitButton")}
+          </button>
           <FileList
             blobs={state.data.pics}
             onSelectedChange={handleSelectedChange}

--- a/src/Pages/CapturPage/CapturPage.tsx
+++ b/src/Pages/CapturPage/CapturPage.tsx
@@ -151,11 +151,9 @@ function CapturPage() {
             file={toShow}
             calculateCaptureCounter={calculateCaptureCounter}
           />
-          {state.data.pics.length > 0 && (
-            <button className="submit-btn" type="button" onClick={Submit}>
+            <button className="submit-btn" type="button" onClick={Submit} disabled={state.data.pics.length === 0}>
               {t("submitButton")}
             </button>
-          )}
           <FileList
             blobs={state.data.pics}
             onSelectedChange={handleSelectedChange}

--- a/src/Pages/FormPage/FormPage.css
+++ b/src/Pages/FormPage/FormPage.css
@@ -3,8 +3,7 @@
   justify-content: space-between;
   padding: 0 10px;
   grid-template-columns: "1fr auto";
-  grid-gap: "1rem";
-  align-items: "start";
+  grid-gap: 1rem;
 }
 
 .disable-scroll{
@@ -68,4 +67,10 @@
 }
 .loader-container-form {
   display: none;
+}
+
+.submit-button{
+  background-color: #dcdcdc;
+  margin-top: 20px;
+  width: 50%;
 }

--- a/src/Pages/FormPage/FormPage.css
+++ b/src/Pages/FormPage/FormPage.css
@@ -7,6 +7,10 @@
   align-items: "start";
 }
 
+.disable-scroll{
+  overflow:-moz-hidden-unscrollable;
+}
+
 @media only screen and (min-width: 1231px) {
   /*the minimum place that need the form to have when he is in full page mode is 1231*/
   .formPage-container {
@@ -34,13 +38,6 @@
   right: 0;
 }
 
-@media (prefers-color-scheme: dark) {
-  .open-icon {
-    filter: invert(74%) sepia(37%) saturate(0%) hue-rotate(249deg)
-      brightness(101%) contrast(98%);
-  }
-}
-
 /* Text box container styles */
 .data-container {
   grid-area: data;
@@ -54,126 +51,6 @@
   font-family: Arial, sans-serif, Bold;
   color: #000000;
   font-size: 20px;
-}
-
-.data-container h1 {
-  text-align: left;
-  margin-left: 20px;
-  font-size: 40px;
-}
-
-.data-container label {
-  text-align: left;
-  margin-left: 20px;
-}
-
-.textbox-container {
-  display: flex; /* Enable flexbox layout */
-  justify-content: left; /* Center horizontally within the container */
-  align-items: center; /* Center vertically within the container */
-  width: 45vw; /* Make the container take up the full width */
-  margin-left: 20px;
-  flex-direction: row;
-}
-
-.underlined {
-  text-decoration: underline;
-}
-
-/* Text box styles */
-textarea {
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  box-sizing: border-box;
-  width: 100rem;
-  height: auto;
-  min-height: 40px;
-  max-height: 97px;
-  resize: none;
-  background-color: rgb(220, 219, 219);
-  overflow-y: hidden;
-  padding-top: 5px;
-  padding-left: 5px;
-  padding-right: 3px;
-  padding-bottom: 10px;
-  /* Text style properties */
-  font-family: Arial, sans-serif, Bold; /* Specify a fallback font */
-  font-size: 20px;
-  font-weight: 400; /* Normal weight */
-  color: #000000; /* Dark gray */
-  text-decoration: none;
-}
-
-.open-icon {
-  position: relative;
-  margin-left: 30px;
-  width: 120%; /* Make the label take up the full width of the textbox container */
-  font-size: 15px; /* Set font size for the label */
-  text-decoration: underline;
-  color: darkgrey;
-}
-
-.show-more-container {
-  align-self: end;
-  justify-self: end;
-  display: flex;
-  justify-content: flex-end;
-}
-.show-more-container label {
-  width: fit-content;
-}
-
-.data-section {
-  display: flex;
-  flex-direction: column;
-  justify-content: left;
-  align-items: left;
-  gap: 10px;
-}
-
-.input-container {
-  display: grid;
-  grid-template-areas:
-    "label label ."
-    "input input input"
-    ". show-more .";
-
-  grid-template-columns: 20% 60% 20%;
-}
-.input-container label {
-  grid-area: label;
-  align-self: center;
-}
-.input-container .textbox-container {
-  grid-area: input;
-}
-
-.input-container .show-more-container {
-  grid-area: show-more;
-  width: 100%;
-}
-.open-icon {
-  cursor: pointer;
-}
-/** for dark mode */
-@media (prefers-color-scheme: dark) {
-  .open-icon {
-    color: white;
-  }
-}
-
-.button-container {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-left: 20px;
-}
-
-.button {
-  background-color: #dcdcdc;
-}
-.input-error {
-  border: 2px solid red; /* Entoure l'élément d'une bordure rouge */
 }
 
 .loader-container-form.active {

--- a/src/Pages/FormPage/FormPage.tsx
+++ b/src/Pages/FormPage/FormPage.tsx
@@ -354,6 +354,20 @@ const FormPage = () => {
     setState({ ...state, data: { pics: blobs, form: new_data } });
   };
 
+  const [isAnyModalOpen, setIsAnyModalOpen] = useState(false);
+  const handleModalStateChange = (isOpen: boolean) => {
+    setIsAnyModalOpen(isOpen);
+  };
+
+  // Prevent scrolling when a modal is open
+  useEffect(() => {
+    if (isAnyModalOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "visible";
+    }
+  }, [isAnyModalOpen]);
+
   return (
     <StrictMode>
       <div className="formPage-container ${theme}">
@@ -377,14 +391,15 @@ const FormPage = () => {
                     modals={modals}
                     imgs={urls}
                     propagateChange={handleDataChange}
+                    onModalStateChange={handleModalStateChange}
                   ></SectionComponent>
                 );
               })}
-              <button className="button" onClick={submitForm}>
-                {t("submitButton")}
-              </button>
             </div>
           )}
+          <button className="button" onClick={submitForm}>
+            {t("submitButton")}
+          </button>
         </div>
         {!loading ? (
           <div className="progress-wrapper">

--- a/src/Pages/FormPage/FormPage.tsx
+++ b/src/Pages/FormPage/FormPage.tsx
@@ -370,13 +370,15 @@ const FormPage = () => {
 
   return (
     <StrictMode>
-      <div className={"formPage-container ${theme}" }>
+      <div className={"formPage-container ${theme}"}>
         <div className="pic-container">
           <Carousel imgs={urls}></Carousel>
         </div>
         <div className="data-container">
           {loading ? (
-            <div className={`loader-container-form ${loading ? "active " : ""}`}>
+            <div
+              className={`loader-container-form ${loading ? "active " : ""}`}
+            >
               <div className="spinner"></div>
               <p>{t("analyzingText")}</p>
             </div>
@@ -395,11 +397,10 @@ const FormPage = () => {
                   ></SectionComponent>
                 );
               })}
-          <button className="submit-button" onClick={submitForm}>
-            {t("submitButton")}
-          </button>
+              <button className="submit-button" onClick={submitForm}>
+                {t("submitButton")}
+              </button>
             </div>
-            
           )}
         </div>
         {!loading ? (

--- a/src/Pages/FormPage/FormPage.tsx
+++ b/src/Pages/FormPage/FormPage.tsx
@@ -395,11 +395,12 @@ const FormPage = () => {
                   ></SectionComponent>
                 );
               })}
-            </div>
-          )}
-          <button className="button" onClick={submitForm}>
+          <button className="submit-button" onClick={submitForm}>
             {t("submitButton")}
           </button>
+            </div>
+            
+          )}
         </div>
         {!loading ? (
           <div className="progress-wrapper">

--- a/src/Pages/FormPage/FormPage.tsx
+++ b/src/Pages/FormPage/FormPage.tsx
@@ -359,24 +359,24 @@ const FormPage = () => {
     setIsAnyModalOpen(isOpen);
   };
 
-  // Prevent scrolling when a modal is open
+  // Prevent scrolling useEffect
   useEffect(() => {
-    if (isAnyModalOpen) {
+    if (isAnyModalOpen || loading) {
       document.body.style.overflow = "hidden";
     } else {
       document.body.style.overflow = "visible";
     }
-  }, [isAnyModalOpen]);
+  }, [isAnyModalOpen, loading]);
 
   return (
     <StrictMode>
-      <div className="formPage-container ${theme}">
+      <div className={"formPage-container ${theme}" }>
         <div className="pic-container">
           <Carousel imgs={urls}></Carousel>
         </div>
         <div className="data-container">
           {loading ? (
-            <div className={`loader-container-form ${loading ? "active" : ""}`}>
+            <div className={`loader-container-form ${loading ? "active " : ""}`}>
               <div className="spinner"></div>
               <p>{t("analyzingText")}</p>
             </div>


### PR DESCRIPTION
fixing :

- [x] Modal when open can't scroll main-page; closes #115 
- [x] show more button not a good place, closes #120 
- [x] wrap text in modal correctly (no overflow), closes #111 
- [x] Single scroll bar in modal when textarea is open, closes #110 
- [x] closes, #60 
- [x] Fixing a non issue that is : As a user, I want to see the submit button on capturPage even when there is no file on the list but I want it to be disabled.
- [x] Fixing positioning of the file list on capturPage.
- [x] Fixing as a user, I don't want to be able to scroll horizontally on the fileListComponent.

Bug found during this PR:

![image](https://github.com/ai-cfia/fertiscan-frontend/assets/73604556/1e4ca426-f35f-4c5d-b07b-f48b0e869b1e)

- [x] Fixed

Moving css of inputComponent into input.css